### PR TITLE
Switch to @libsql/client to support remote database connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@atcute/client": "^2.0.3",
 		"@atcute/ozone": "^1.0.4",
 		"@fastify/websocket": "^10.0.1",
+		"@libsql/client": "^0.14.0",
 		"@noble/curves": "^1.6.0",
 		"@noble/hashes": "^1.5.0",
 		"fastify": "^4.28.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"@noble/curves": "^1.6.0",
 		"@noble/hashes": "^1.5.0",
 		"fastify": "^4.28.1",
-		"libsql": "^0.4.6",
 		"prompts": "^2.4.2",
 		"uint8arrays": "^5.1.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fastify/websocket':
         specifier: ^10.0.1
         version: 10.0.1
+      '@libsql/client':
+        specifier: ^0.14.0
+        version: 0.14.0
       '@noble/curves':
         specifier: ^1.6.0
         version: 1.6.0
@@ -173,6 +176,12 @@ packages:
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
 
+  '@libsql/client@0.14.0':
+    resolution: {integrity: sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==}
+
+  '@libsql/core@0.14.0':
+    resolution: {integrity: sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q==}
+
   '@libsql/darwin-arm64@0.4.6':
     resolution: {integrity: sha512-45i604CJ2Lubbg7NqtDodjarF6VgST8rS5R8xB++MoRqixtDns9PZ6tocT9pRJDWuTWEiy2sjthPOFWMKwYAsg==}
     cpu: [arm64]
@@ -182,6 +191,16 @@ packages:
     resolution: {integrity: sha512-dRKliflhfr5zOPSNgNJ6C2nZDd4YA8bTXF3MUNqNkcxQ8BffaH9uUwL9kMq89LkFIZQHcyP75bBgZctxfJ/H5Q==}
     cpu: [x64]
     os: [darwin]
+
+  '@libsql/hrana-client@0.7.0':
+    resolution: {integrity: sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==}
+
+  '@libsql/isomorphic-fetch@0.3.1':
+    resolution: {integrity: sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==}
+    engines: {node: '>=18.0.0'}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
 
   '@libsql/linux-arm64-gnu@0.4.6':
     resolution: {integrity: sha512-DMPavVyY6vYPAYcQR1iOotHszg+5xSjHSg6F9kNecPX0KKdGq84zuPJmORfKOPtaWvzPewNFdML/e+s1fu09XQ==}
@@ -407,6 +426,10 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -530,6 +553,10 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -552,6 +579,10 @@ packages:
 
   flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -633,6 +664,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -701,6 +735,14 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -767,6 +809,9 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -930,6 +975,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1065,11 +1114,46 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.2': {}
 
+  '@libsql/client@0.14.0':
+    dependencies:
+      '@libsql/core': 0.14.0
+      '@libsql/hrana-client': 0.7.0
+      js-base64: 3.7.7
+      libsql: 0.4.6
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.14.0':
+    dependencies:
+      js-base64: 3.7.7
+
   '@libsql/darwin-arm64@0.4.6':
     optional: true
 
   '@libsql/darwin-x64@0.4.6':
     optional: true
+
+  '@libsql/hrana-client@0.7.0':
+    dependencies:
+      '@libsql/isomorphic-fetch': 0.3.1
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.7.7
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-fetch@0.3.1': {}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.5.12
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@libsql/linux-arm64-gnu@0.4.6':
     optional: true
@@ -1300,6 +1384,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -1472,6 +1558,11 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -1498,6 +1589,10 @@ snapshots:
       rimraf: 3.0.2
 
   flatted@3.2.9: {}
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -1570,6 +1665,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   isexe@2.0.0: {}
+
+  js-base64@3.7.7: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -1644,6 +1741,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -1709,6 +1814,8 @@ snapshots:
   process-warning@4.0.0: {}
 
   process@0.11.10: {}
+
+  promise-limit@2.7.0: {}
 
   prompts@2.4.2:
     dependencies:
@@ -1843,6 +1950,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       fastify:
         specifier: ^4.28.1
         version: 4.28.1
-      libsql:
-        specifier: ^0.4.6
-        version: 0.4.6
       prompts:
         specifier: ^2.4.2
         version: 2.4.2

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -60,13 +60,13 @@ export interface LabelerOptions {
 	 * The URL of the database.
 	 * If provided, dbPath is ignored.
 	 */
-	url?: string;
+	dbUrl?: string;
 
 	/**
 	 * The authentication token for the database.
 	 * Required if url is provided.
 	 */
-	authToken?: string;
+	dbAuthToken?: string;
 }
 
 export class LabelerServer {
@@ -104,13 +104,13 @@ export class LabelerServer {
 			throw new Error(INVALID_SIGNING_KEY_ERROR);
 		}
 
-		if (options.url) {
-			if (!options.authToken) {
+		if (options.dbUrl) {
+			if (!options.dbAuthToken) {
 				throw new Error("authToken is required when using a remote database URL");
 			}
 			this.db = createClient({
-				url: options.url,
-				authToken: options.authToken,
+				url: options.dbUrl,
+				authToken: options.dbAuthToken,
 			});
 		} else {
 			this.db = createClient({

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -198,15 +198,25 @@ export class LabelerServer {
 		const signed = labelIsSigned(label) ? label : signLabel(label, this.#signingKey);
 		const { src, uri, cid, val, neg, cts, exp, sig } = signed;
 
-		const result = await this.db.execute({
-			sql: `
-				INSERT INTO labels (src, uri, cid, val, neg, cts, exp, sig)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-				RETURNING id
-			`,
-			args: [src, uri, cid!, val, neg ? 1 : 0, cts, exp!, sig],
-		});
-		if (!result.rowsAffected) throw new Error("Failed to insert label");
+		const sql = `
+    		INSERT INTO labels (src, uri, cid, val, neg, cts, exp, sig)
+    		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    		RETURNING id
+		`;
+
+		const args = [
+			src,
+			uri,
+			cid || null,
+			val,
+			neg ? 1 : 0,
+			cts,
+			exp || null,
+			sig
+		];
+
+		const result = await this.db.execute({ sql, args });
+		if (!result.rows.length) throw new Error("Failed to insert label");
 
 		const id = Number(result.rows[0].id);
 

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -137,35 +137,35 @@ export class LabelerServer {
 		});
 	}
 
-    /**
-     * Initializes the database with required schema.
-     * Called during constructor and creates a promise tracked by dbInitLock.
-     * All database operations should await dbInitLock to ensure initialization is complete.
-     * @returns Promise that resolves when initialization is complete
-     * @throws Error if database initialization fails
-     */
-    private async initializeDatabase() {
-        await this.db.execute("PRAGMA journal_mode = WAL").catch(() => {
-            console.warn("Unable to set WAL mode - performance and concurrent access may be impacted");
-        });
+	/**
+	 * Initializes the database with required schema.
+	 * Called during constructor and creates a promise tracked by dbInitLock.
+	 * All database operations should await dbInitLock to ensure initialization is complete.
+	 * @returns Promise that resolves when initialization is complete
+	 * @throws Error if database initialization fails
+	 */
+	private async initializeDatabase() {
+		await this.db.execute("PRAGMA journal_mode = WAL").catch(() => {
+			console.warn("Unable to set WAL mode - performance and concurrent access may be impacted");
+		});
 
-        await this.db.execute(`
-            CREATE TABLE IF NOT EXISTS labels (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                src TEXT NOT NULL,
-                uri TEXT NOT NULL,
-                cid TEXT,
-                val TEXT NOT NULL,
-                neg BOOLEAN DEFAULT FALSE,
-                cts DATETIME NOT NULL,
-                exp DATETIME,
-                sig BLOB
-            );
-        `).catch(error => {
-            console.error("Failed to initialize database:", error);
-            throw error;
-        });
-    }
+		await this.db.execute(`
+			CREATE TABLE IF NOT EXISTS labels (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				src TEXT NOT NULL,
+				uri TEXT NOT NULL,
+				cid TEXT,
+				val TEXT NOT NULL,
+				neg BOOLEAN DEFAULT FALSE,
+				cts DATETIME NOT NULL,
+				exp DATETIME,
+				sig BLOB
+			);
+		`).catch(error => {
+			console.error("Failed to initialize database:", error);
+			throw error;
+		});
+	}
 
 	/**
 	 * Start the server.

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -145,26 +145,26 @@ export class LabelerServer {
 	 * @throws Error if database initialization fails
 	 */
 	private async initializeDatabase() {
-		await this.db.execute("PRAGMA journal_mode = WAL").catch(() => {
+        await this.db.execute("PRAGMA journal_mode = WAL").catch(() => {
             console.warn("Unable to set WAL mode - performance and concurrent access may be impacted");
         });
 
-		await this.db.execute(`
-           CREATE TABLE IF NOT EXISTS labels (
-               id INTEGER PRIMARY KEY AUTOINCREMENT,
-               src TEXT NOT NULL,
-               uri TEXT NOT NULL,
-               cid TEXT,
-               val TEXT NOT NULL,
-               neg BOOLEAN DEFAULT FALSE,
-               cts DATETIME NOT NULL,
-               exp DATETIME,
-               sig BLOB
-           );
-       `).catch(error => {
-			console.error("Failed to initialize database:", error);
-			throw error;
-		});
+        await this.db.execute(`
+            CREATE TABLE IF NOT EXISTS labels (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                src TEXT NOT NULL,
+                uri TEXT NOT NULL,
+                cid TEXT,
+                val TEXT NOT NULL,
+                neg BOOLEAN DEFAULT FALSE,
+                cts DATETIME NOT NULL,
+                exp DATETIME,
+                sig BLOB
+            );
+        `).catch(error => {
+            console.error("Failed to initialize database:", error);
+            throw error;
+        });
 	}
 
 	/**

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -137,14 +137,14 @@ export class LabelerServer {
 		});
 	}
 
-	/**
-	 * Initializes the database with required schema.
-	 * Called during constructor and creates a promise tracked by dbInitLock.
-	 * All database operations should await dbInitLock to ensure initialization is complete.
-	 * @returns Promise that resolves when initialization is complete
-	 * @throws Error if database initialization fails
-	 */
-	private async initializeDatabase() {
+    /**
+     * Initializes the database with required schema.
+     * Called during constructor and creates a promise tracked by dbInitLock.
+     * All database operations should await dbInitLock to ensure initialization is complete.
+     * @returns Promise that resolves when initialization is complete
+     * @throws Error if database initialization fails
+     */
+    private async initializeDatabase() {
         await this.db.execute("PRAGMA journal_mode = WAL").catch(() => {
             console.warn("Unable to set WAL mode - performance and concurrent access may be impacted");
         });
@@ -165,7 +165,7 @@ export class LabelerServer {
             console.error("Failed to initialize database:", error);
             throw error;
         });
-	}
+    }
 
 	/**
 	 * Start the server.


### PR DESCRIPTION
## Problem
When deploying the labeler server on container platforms with ephemeral file systems (e.g., Heroku, Railway), the SQLite database file would get deleted on each deploy since the filesystem is not persistent. This makes it difficult to maintain label history across deployments

## Solution
The [@libsql/client](https://github.com/tursodatabase/libsql-client-ts) supports both local SQLite files and remote database connections. This PR updates the labeler server to:

1. Replace the previous SQLite client with `@libsql/client`
2. Add optional database connection parameters:
   - `url` - Remote database URL (e.g., "libsql://your-db.skyware.js.org")
   - `authToken` - Authentication token for remote database

## Usage
```typescript
// Local SQLite (existing behavior)
const server = new LabelerServer({
  did: "did:example:123",
  signingKey: "your-key",
  dbPath: "labels.db"
});

// Remote database
const server = new LabelerServer({
  did: "did:example:123",
  signingKey: "your-key",
  url: "libsql://your-db.skyware.js.org",
  authToken: "your-auth-token"
});