### PR TITLE
Support any database via hook / callback pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ server.start(14831, (error, address) => {
     }
 });
 ```
+
+# Advanced
+
+## Bringing Your Own Database
+`@skyware/labeler` uses libsql by default, but can be configured prograamatically to use any database of your choosing. Instead of creating an ORM, the labeler constructor exposes a `dbCallbacks` property for registering your database callbacks for every significant operation. All callbacks are asynchronous, although it's your responsibility to check the resolved state of your connection before performing additional operations.
+
+A sample implementation can be found in `src/util/sqlite.ts`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-export { type LabelerOptions, LabelerServer } from "./LabelerServer.js";
+export { LabelerServer } from "./LabelerServer.js";
 export { formatLabel, labelIsSigned, signLabel } from "./util/labels.js";
 export type {
 	CreateLabelData,
 	FormattedLabel,
+	LabelerOptions,
 	ProcedureHandler,
 	QueryHandler,
 	SavedLabel,

--- a/src/util/sqlite.ts
+++ b/src/util/sqlite.ts
@@ -1,0 +1,89 @@
+import Database, { type Database as SQLiteDatabase } from "libsql";
+import type {
+	DBCallbacks,
+	SavedLabel,
+} from "./types.js";
+
+/**
+ * Creates the default set of sqlite callbacks
+ */
+export const createSqliteCallbacks: () => DBCallbacks = () => {
+	let db: SQLiteDatabase;
+	return {
+		async connect(options) {
+			db = new Database(options.dbPath ?? "labels.db");
+			db.pragma("journal_mode = WAL");
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS labels (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					src TEXT NOT NULL,
+					uri TEXT NOT NULL,
+					cid TEXT,
+					val TEXT NOT NULL,
+					neg BOOLEAN DEFAULT FALSE,
+					cts DATETIME NOT NULL,
+					exp DATETIME,
+					sig BLOB
+				);
+			`);
+		},
+		async close() {
+			db.close();
+		},
+		async createLabel(label) {
+			const stmt = db.prepare(`
+				INSERT INTO labels (src, uri, cid, val, neg, cts, exp, sig)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`);
+	
+			const { src, uri, cid, val, neg, cts, exp, sig } = label;
+			const result = stmt.run(src, uri, cid, val, neg ? 1 : 0, cts, exp, sig);
+			if (!result.changes) throw new Error("Failed to insert label");
+	
+			const id = Number(result.lastInsertRowid);
+
+			return { id, ...label };
+		},
+		async findLabels(query) {
+			const { uriPatterns: patterns, sources, after: cursor, limit} = query;
+
+			const stmt = db.prepare(`
+				SELECT * FROM labels
+				WHERE 1 = 1
+				${patterns?.length ? "AND " + patterns.map(() => "uri LIKE ?").join(" OR ") : ""}
+				${sources?.length ? `AND src IN (${sources.map(() => "?").join(", ")})` : ""}
+				${cursor ? "AND id > ?" : ""}
+				ORDER BY id ASC
+				LIMIT ?
+			`);
+	
+			const params = [];
+			if (patterns?.length) params.push(...patterns);
+			if (sources?.length) params.push(...sources);
+			if (cursor) params.push(cursor);
+			params.push(limit);
+	
+			const rows = stmt.all(params) as Array<SavedLabel>;
+
+			return rows;
+		},
+		async getLatestLabel() {
+			const stmt = db.prepare(`
+				SELECT * FROM labels
+				ORDER BY id DESC
+				LIMIT 1
+			`);
+	
+			return stmt.get() as SavedLabel;
+		},
+		async getAllLabels(query) {
+			const stmt = db.prepare(`
+				SELECT * FROM labels
+				WHERE id > ?
+				ORDER BY id ASC
+			`);
+	
+			return stmt.all(query.after) as Array<SavedLabel>;
+		},
+	};
+}


### PR DESCRIPTION
# Motivation
This enables developers to "swap" in any database layer should they outgrow the default sqlite implementation. This also makes it possible to bring in sqlite alternatives like Turso which rely on network connections and therefore must be asynchronous.

The hooks/callback pattern remains a successful DB adapter pattern from Auth0, Clerk, and others, which do not dictate an ORM layer, leaving that to the person who is extending the core functionality.

# Summary of Changes
* Makes all methods asynchronous, minimizing the total changeset. I realize this can introduce unhandled exceptions if the async methods threw, but I wanted to prioritize a smaller diff
* Adds a `DBCallbacks` type that describes the current set of database callbacks
* Moves the sqlite operations into their own set of callbacks in `src/util/sqlite.ts` for backwards compatibility
* Updates the readme, referencing the sqlite code as a template other developers can reference

# Risks
This exposes a new API which comes with backwards compatibility concerns. Adding new functionality to the labeler which also adds a new Database call becomes a breaking change. I don't think this is a concern, as people **should** be pinning their dependency on skyware.

# Open Issues 
* [ ] `getAllLabels` in the driver seems to be missing a limit and I can't for the life of me remember if that's automatically handled by `stmt.iterate(cursor)` or not.
* [ ] Would we want `DBCallbacks` to be part of the exports