### PR TITLE
feat: add CLI arguments for non-interactive automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-	"name": "@skyware/labeler",
+	"name": "johnwarden-labeler",
 	"type": "module",
-	"description": "A lightweight alternative to Ozone for operating an atproto labeler.",
-	"version": "0.2.0",
+	"description": "A fork of @skyware/labeler with CLI argument support for non-interactive setup.",
+	"version": "0.2.2",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"bin": "dist/bin.js",
 	"license": "MPL-2.0",
-	"repository": "https://github.com/skyware-js/labeler",
-	"homepage": "https://skyware.js.org/docs/labeler",
+	"repository": "https://github.com/johnwarden/labeler",
+	"homepage": "https://github.com/johnwarden/labeler",
 	"keywords": [
 		"bluesky",
 		"labeler",
@@ -44,9 +44,11 @@
 		"@libsql/client": "^0.14.0",
 		"@noble/curves": "^1.6.0",
 		"@noble/hashes": "^1.5.0",
+		"@types/yargs": "^17.0.33",
 		"fastify": "^4.28.1",
 		"prompts": "^2.4.2",
-		"uint8arrays": "^5.1.0"
+		"uint8arrays": "^5.1.0",
+		"yargs": "^18.0.0"
 	},
 	"files": [
 		"dist"

--- a/src/LabelerServer.ts
+++ b/src/LabelerServer.ts
@@ -235,7 +235,7 @@ export class LabelerServer {
 		const id = Number(result.rows[0].id);
 
 		this.emitLabel(id, signed);
-		return { id, ...signed };
+		return { id, ...signed, sig: signed.sig.buffer as ArrayBuffer };
 	}
 
 	/**
@@ -422,7 +422,7 @@ export class LabelerServer {
 			cts: row.cts as string,
 			...(row.cid ? { cid: row.cid as string } : {}),
 			...(row.exp ? { exp: row.exp as string } : {}),
-			...(row.sig ? { sig: row.sig as Uint8Array } : {}),
+			...(row.sig ? { sig: new Uint8Array(row.sig as ArrayBuffer) } : {}),
 		}));
 		const labels = rows.map(formatLabel);
 
@@ -473,7 +473,7 @@ export class LabelerServer {
 						cts: cts as string,
 						...(cid ? { cid: cid as string } : {}),
 						...(exp ? { exp: exp as string } : {}),
-						...(sig ? { sig: sig as Uint8Array } : {}),
+						...(sig ? { sig: new Uint8Array(sig as ArrayBuffer) } : {}),
 					};
 					const bytes = frameToBytes("message", {
 						seq: Number(seq),


### PR DESCRIPTION
## Summary

This PR adds CLI argument support to the `setup`, `clear`, and `recreate` commands, enabling non-interactive automation while maintaining security for sensitive operations.

## Changes

### Added CLI Arguments
- **`setup`**: `--did`, `--password`, `--pds`, `--endpoint`, `--signing-key`, `--labels-config`
- **`clear`**: `--did`, `--password`, `--pds` 
- **`recreate`**: `--did`, `--password`, `--pds`

### Key Features
- 🔧 **Non-interactive automation**: Commands can run without user prompts when CLI args provided
- 🛡️ **Security maintained**: PLC token remains interactive (email confirmation required)
- 🔄 **Backward compatible**: Falls back to interactive prompts when CLI args not provided
- 📦 **Robust parsing**: Uses yargs for professional CLI argument handling

### Use Cases
This enables:
- **CI/CD automation**: Automated labeler setup in deployment pipelines
- **Development workflows**: Quick recreation of labeler declarations
- **Scripted operations**: Batch operations and infrastructure as code

### Example Usage
```bash
# Non-interactive setup (PLC token still prompted for security)
npx @skyware/labeler setup --did=$DID --password=$PASSWORD --endpoint=https://labeler.example.com

# Fully non-interactive recreate
npx @skyware/labeler recreate --did=$DID --password=$PASSWORD

# Clear with minimal interaction (PLC token prompted)
npx @skyware/labeler clear --did=$DID --password=$PASSWORD
```
