### PR TITLE
Refactor: LabelerServer.create for async initialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,7 @@ export { formatLabel, labelIsSigned, signLabel } from "./util/labels.js";
 export type {
 	CreateLabelData,
 	FormattedLabel,
-	ProcedureHandler,
-	QueryHandler,
 	SavedLabel,
 	SignedLabel,
-	SubscriptionHandler,
 	UnsignedLabel,
 } from "./util/types.js";


### PR DESCRIPTION
This provides us the API suggested in #14, where we have:

```ts
const labeler = await LabelerServer.create({ ... })

// labeler.app.<method> => direct access to fastify

await labeler.start(3000) // or: await labeler.start({ port: 3000, host: '127.0.0.1' })
await labeler.stop()
```

This is a **breaking change** in the public API, whilst you can still use the constructor, it's not recommended.

This does however fix #8, allowing for people to extend the server.